### PR TITLE
Add move to a parent feature

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Test with pytest
         run: |
           pip install pytest pytest-cov
-          pytest ./test/todoist_prioritizer_test.py --doctest-modules --junitxml=junit/test-results.xml
-          pytest --cov --cov-report=xml --junitxml=junit.xml
+          pytest ./test --doctest-modules --junitxml=junit/test-results.xml
+          pytest --cov=src --cov-report=xml --junitxml=junit.xml
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The todoist-prioritizer is a Python script designed to manage Todoist tasks prio
 - Specify number of tasks with no duration and max. duration for tasks to fill for today view
 - The script will fill tasks for today view until user set requirements are met
 - The script runs once a day at a time specified by the user
+- If the user sets a parent project id, the script will move the oldest P1 task to that project
 
 # Usage
 If the script is run without arguments, it will prompt for user input. This is true for just executing .exe too. Only Todoist api token needs to be set, the user can run other settings with default values. The api token is available at [integrations/developer](https://todoist.com/prefs/integrations).
@@ -32,20 +33,21 @@ Available commands
 ```bash
 todoist-prioritizer --help
 usage: todoist_prioritizer.py [-h] [-a API_TOKEN] [-p1 P1_SIZE] [-p2 P2_SIZE] [-p3 P3_SIZE] [-hh RUN_HOUR]
-                              [-mm RUN_MINUTE] [-nd TASKS_SIZE] [-du DURATION_MIN] [-r] [-d]
+                              [-mm RUN_MINUTE] [-nd TASKS_SIZE] [-du DURATION_MIN] [-p PARENT_PROJECT_ID] [-r] [-d]
 
 options:
-  -h, --help                     show this help message and exit
-  -a API_TOKEN, --api API_TOKEN  Set api token
-  -p1 P1_SIZE                    Maximum number of P1 tasks
-  -p2 P2_SIZE                    Maximum number of P2 tasks
-  -p3 P3_SIZE                    Maximum number of P3 tasks
-  -hh RUN_HOUR                   The hour to run the script, 24 hour format
-  -mm RUN_MINUTE                 The minute to run the script, 24 hour format
-  -nd TASKS_SIZE                 Number of tasks with no duration to prioritize for today
-  -du DURATION_MIN               Maximum tasks duration in minutes to prioritize for today
-  -r, --reset                    Reset configuration to default values
-  -d, --debug                    Enable debug logging level
+  -h, --help                                        show this help message and exit
+  -a API_TOKEN, --api API_TOKEN                     Set api token
+  -p1 P1_SIZE                                       Maximum number of P1 tasks
+  -p2 P2_SIZE                                       Maximum number of P2 tasks
+  -p3 P3_SIZE                                       Maximum number of P3 tasks
+  -hh RUN_HOUR                                      The hour to run the script, 24 hour format
+  -mm RUN_MINUTE                                    The minute to run the script, 24 hour format
+  -nd TASKS_SIZE                                    Number of tasks with no duration to prioritize for today
+  -du DURATION_MIN                                  Maximum tasks duration in minutes to prioritize for today
+  -p PARENT_PROJECT_ID, --parent PARENT_PROJECT_ID  If set move oldest P1 task to this parent project
+  -r, --reset                                       Reset configuration to default values
+  -d, --debug                                       Enable debug logging level
 ```
 
 Example usage  

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,6 @@
 coverage:
+  include:
+    - "src/*"
   status:
     project: # add everything under here, more options at https://docs.codecov.com/docs/commit-status
       default: # status check name
@@ -8,6 +10,6 @@ coverage:
           - "src"
     patch:
       default:
-        target: 100%
+        target: 80%
         paths:
           - "src"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ﻿keyring==25.6.0
 requests==2.32.3
 todoist-api-python==3.1.0
+tzdata==2025.2

--- a/src/CommandLineParser.py
+++ b/src/CommandLineParser.py
@@ -89,6 +89,13 @@ class CommandLineParser:
             help="Maximum tasks duration in minutes to prioritize for today",
         )
         self.parser.add_argument(
+            "-p",
+            "--parent",
+            type=str,
+            metavar="PARENT_PROJECT_ID",
+            help="If set move oldest P1 task to this parent project",
+        )
+        self.parser.add_argument(
             "-r",
             "--reset",
             action="store_true",
@@ -151,6 +158,10 @@ class CommandLineParser:
             config.set("USER", "task_duration", str(self.args.du))
             with open(ini_path, "w") as configfile:
                 config.write(configfile)
+        if self.args.parent is not None:
+            config.set("USER", "parent_id", str(self.args.parent))
+            with open(ini_path, "w") as configfile:
+                config.write(configfile)
         if self.args.reset:
             config.set("USER", "p1_tasks", config.get("DEFAULT", "p1_tasks"))
             config.set("USER", "p2_tasks", config.get("DEFAULT", "p2_tasks"))
@@ -190,6 +201,9 @@ class CommandLineParser:
                     self.args.du = input(
                         "Enter maximum duration for tasks to prioritize for today view: "
                     )
+                    arg = input("Move oldest P1 task to new parent project? (y/n): ")
+                    if arg == "y":
+                        self.args.p = input("Enter parent project id: ")
                     self.args.debug = input("Debug logging? (y/n): ")
                     if self.args.debug == "y":
                         self.args.debug = True

--- a/src/config.ini
+++ b/src/config.ini
@@ -6,6 +6,7 @@ run_hour = 3
 run_minute = 0
 number_of_tasks = 1
 task_duration = 30
+parent_id = None
 
 [USER]
 p1_tasks = 5
@@ -15,3 +16,4 @@ run_hour = 3
 run_minute = 0
 number_of_tasks = 1
 task_duration = 30
+parent_id = None

--- a/src/todoist_prioritizer.py
+++ b/src/todoist_prioritizer.py
@@ -46,16 +46,19 @@ def get_tasks(filters: str) -> list:
     @return The list of tasks from the Todoist API
     """
 
-    tasks = []
+    tasks_lists = []
+    tasks_list = []
     try:
-        tasks = api_token.get_tasks(filter=filters)
+        tasks_lists = api_token.filter_tasks(query=filters)
     except Exception as error:
         logging.error(error)
         sys.exit(1)
     logging.debug(f"({filters}) filtered tasks:\n")
-    for task in tasks:
-        logging.debug(f"{task.content}")
-    return tasks
+    for task_list in tasks_lists:
+        for task in task_list:
+            tasks_list.append(task)
+            logging.debug(f"{task.content}")
+    return tasks_list
 
 
 def sort_tasks_date(tasks: list) -> list:
@@ -113,6 +116,39 @@ def prioritize_tasks(tasks: list, p: int, max_size: int) -> list:
     return tasks
 
 
+def move_task_to_a_parent(task: object, parent_id: str) -> None:
+    """!
+    Move a task to today
+
+    @param task The task to move
+    """
+
+    task_duration = task.duration
+    if task_duration == None:
+        task_duration = 60
+    else:
+        task_duration = task.duration.amount
+    retval = api_token.update_task(
+        task_id=task.id,
+        due_string="today at 18:00",
+        duration=task_duration,
+        duration_unit="minute",
+    )
+    if retval is None:
+        logging.error(f"Failed to move {task.content} to today")
+        sys.exit(1)
+
+    try:
+        api_token.move_task(
+            task_id=task.id,
+            project_id=parent_id,
+        )
+        logging.info(f"Moved {task.content} to today\n")
+    except Exception as error:
+        logging.error(error)
+        sys.exit(1)
+
+
 def fill_today_tasks(
     tasks_pool: list, task_reschedule_time: datetime.datetime
 ) -> datetime.datetime:
@@ -132,6 +168,7 @@ def fill_today_tasks(
 
     # Get current number of tasks with no duration and total duration
     for task in today_tasks:
+        logging.debug(f"Task: {task}")
         if task.duration == None:
             no_duration_tasks_pcs += 1
         elif task.duration.amount > 0:
@@ -143,6 +180,7 @@ def fill_today_tasks(
     for task in tasks_pool:
         # Tasks with no duration
         if no_duration_tasks_pcs < usr_no_duration_tasks_pcs:
+            logging.debug(f"Task: {task}")
             if task.duration == None:
                 no_duration_tasks_pcs += 1
                 due_str = f"today at {task_reschedule_time.hour:02}:{task_reschedule_time.minute:02}"
@@ -271,6 +309,11 @@ if __name__ == "__main__":
             reschedule_starting_time = fill_today_tasks(
                 p4_tasks, reschedule_starting_time
             )
+
+            # Move the first P1 task to a parent
+            parent_id = config.get("USER", "parent_id")
+            if parent_id != "None" and p1_tasks:
+                move_task_to_a_parent(p1_tasks[0], parent_id)
 
             check_for_updates()
             sleep(60)  # Run only once

--- a/test/command_line_parser_test.py
+++ b/test/command_line_parser_test.py
@@ -1,0 +1,82 @@
+import unittest
+from unittest.mock import patch
+import sys
+import os
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
+from CommandLineParser import CommandLineParser
+
+
+class CommandLineParserTest(unittest.TestCase):
+    def setUp(self):
+        # Patch configparser to avoid writing to disk
+        patcher = patch("CommandLineParser.configparser.ConfigParser")
+        self.addCleanup(patcher.stop)
+        self.mock_config = patcher.start()()
+        self.mock_config.read.return_value = None
+
+    def test_parse_args_with_api_token(self):
+        test_args = ["prog", "-a", "test-token"]
+        with patch.object(sys, "argv", test_args), patch(
+            "CommandLineParser.keyring.set_password"
+        ) as mock_set_password:
+            parser = CommandLineParser()
+            self.assertEqual(parser.args.api, "test-token")
+            mock_set_password.assert_called_with(
+                "system", "todoist-api-token", "test-token"
+            )
+
+    def test_parse_args_with_priorities(self):
+        test_args = ["prog", "-p1", "3", "-p2", "5", "-p3", "7"]
+        with patch.object(sys, "argv", test_args):
+            parser = CommandLineParser()
+            self.assertEqual(parser.args.p1, 3)
+            self.assertEqual(parser.args.p2, 5)
+            self.assertEqual(parser.args.p3, 7)
+
+    def test_parse_args_with_run_time(self):
+        test_args = ["prog", "-hh", "10", "-mm", "30"]
+        with patch.object(sys, "argv", test_args):
+            parser = CommandLineParser()
+            self.assertEqual(parser.args.hh, 10)
+            self.assertEqual(parser.args.mm, 30)
+
+    def test_parse_args_with_task_limits(self):
+        test_args = ["prog", "-nd", "2", "-du", "45"]
+        with patch.object(sys, "argv", test_args):
+            parser = CommandLineParser()
+            self.assertEqual(parser.args.nd, 2)
+            self.assertEqual(parser.args.du, 45)
+
+    def test_parse_args_with_parent_and_reset(self):
+        test_args = ["prog", "-p", "parentid", "-r"]
+        with patch.object(sys, "argv", test_args), patch("sys.exit") as mock_exit:
+            parser = CommandLineParser()
+            self.assertEqual(parser.args.parent, "parentid")
+            self.assertTrue(parser.args.reset)
+            mock_exit.assert_called()
+
+    def test_parse_args_with_debug(self):
+        test_args = ["prog", "-d"]
+        with patch.object(sys, "argv", test_args):
+            parser = CommandLineParser()
+            self.assertTrue(parser.args.debug)
+
+    def test_user_input_configure(self):
+        user_inputs = iter(
+            ["y", "n", "api-token", "2", "3", "4", "12", "34", "5", "60", "n", "n"]
+        )
+        with patch("builtins.input", lambda prompt: next(user_inputs)), patch(
+            "sys.exit"
+        ) as mock_exit:
+            parser = CommandLineParser()
+            parser.args.api = None
+            with patch.object(CommandLineParser, "parse_args") as mock_parse_args:
+                parser.user_input()
+                mock_parse_args.assert_called_with(True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/todoist_prioritizer_test.py
+++ b/test/todoist_prioritizer_test.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 import sys
 import os
+
 src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
 sys.path.insert(0, src_dir)
 
@@ -182,11 +183,11 @@ class TodoistPrioritizerHelperFunctionsTest(unittest.TestCase):
         ]
 
         with patch("todoist_prioritizer.api_token") as mock_api_token:
-            mock_api_token.get_tasks.return_value = expected_tasks
+            mock_api_token.filter_tasks.return_value = [expected_tasks]
             tasks = get_tasks("P1")
             self.assertTrue(all(task.priority == desired_priority for task in tasks))
             self.assertEqual(tasks, expected_tasks)
-            mock_api_token.get_tasks.assert_called_with(filter="P1")
+            mock_api_token.filter_tasks.assert_called_with(query="P1")
 
     def test_sort_tasks_date(self):
         sorted_tasks = sort_tasks_date(self.tasks)


### PR DESCRIPTION
- added: feature to move first P1 task to a different project
- added: `--parent` option to give the project id
- changed: only scan `src` code coverage
- added: unittests for `CommandLineParser`